### PR TITLE
Add localization text in niveristand-routing-and-faulting-cd control…

### DIFF
--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -14,3 +14,13 @@ XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Routing and Faulting for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
 Recommends: ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version})
+Description-zh-CN: 为NI VeriStand {veristand_version}提供Routing and Faulting自定义设备的支持
+XB-DisplayName-zh-CN: NI Routing and Faulting for VeriStand {veristand_version}
+Description-de: tellt Unterstützung für benutzerdefinierte &quot;Routing and Faulting&quot; Geräte für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI Routing and Faulting für VeriStand {veristand_version}
+Description-fr: Fournit le support pour le périphérique personnalisé Routing and Faulting pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI Routing and Faulting for VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用のRouting and Faultingカスタムデバイスのサポートを提供します
+XB-DisplayName-ja: NI Routing and Faulting - VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 Routing and Faulting Custom Device의 지원을 제공합니다.
+XB-DisplayName-ko: NI Routing and Faulting - VeriStand {veristand_version} 지원


### PR DESCRIPTION
… page

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-routing-and-faulting control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress