### PR TITLE
Add localization text in niveristand-routing-and-faulting-custom-device-ni-switch-LabVIEW-Example control page

### DIFF
--- a/control_ni_switch_examples
+++ b/control_ni_switch_examples
@@ -13,3 +13,13 @@ Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Examples for VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-support (>= {display_version})
+Description-zh-CN: 为NI VeriStand {veristand_version}提供NI-SWITCH自定义设备的LabVIEW范例
+XB-DisplayName-zh-CN: VeriStand {veristand_version}的NI-SWITCH LabVIEW范例
+Description-de: Stellt LabVIEW-Beispiele für benutzerdefinierte NI-SWITCH-Geräte für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI-SWITCH - LabVIEW-Beispiele für VeriStand {veristand_version}
+Description-fr: Fournit des exemples LabVIEW pour le périphérique personnalisé NI-SWITCH pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI-SWITCH - Exemples LabVIEW pour VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用のNI-SWITCHカスタムデバイスのLabVIEWサンプルプログラムを提供します
+XB-DisplayName-ja: NI-SWITCH LabVIEWサンプルプログラム - VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 NI-SWITCH Custom Device의 LabVIEW 예제를 제공합니다.
+XB-DisplayName-ko: NI-SWITCH Switch LabVIEW Examples - VeriStand {veristand_version} 지원


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-routing-and-faulting-custom-device-ni-switch-LabVIEW-Example control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress